### PR TITLE
Fix sed BRE

### DIFF
--- a/zfSnap.sh
+++ b/zfSnap.sh
@@ -394,7 +394,7 @@ while [ "$1" ]; do
     fi
 done
 
-prefixes=`echo "$prefixes" | sed -e 's/^\|//'`
+prefixes=`echo "$prefixes" | sed -e 's/^|//'`
 
 # delete snapshots
 if IsTrue $delete_snapshots || [ $force_delete_snapshots_age -ne -1 ]; then


### PR DESCRIPTION
This sed BRE didn't work properly. Pipe does not need to be escaped here. In sed BRE, only $.*[]^ need to be escaped.

For more, see: http://unix.stackexchange.com/questions/32907/what-characters-do-i-need-to-escape-when-using-sed-in-a-sh-script

---Alex
