### PR TITLE
Use getopts to parse script options

### DIFF
--- a/tests/unit/getopts.sh
+++ b/tests/unit/getopts.sh
@@ -8,10 +8,10 @@ zfSnap="../../zfSnap.sh"
 # All are preceeded with -n for safety
 ItReturns "$zfSnap -n -a"                               1 # -a requires an argument
 ItReturns "$zfSnap -n -F"                               1 # -F requires an argument
-ItReturns "$zfSnap -n -a 1d -r fake_zpool -v"           1 # generic option after a pool option
+ItReturns "$zfSnap -g"                                  1 # -g is not a valid option
 
 # These are valid scenarios and should be accepted
-ItReturns "$zfSnap -n -v -v"                            0 # generic option twice is ok, though pointless
+ItReturns "$zfSnap -n -v -v"                            0 # option twice is ok, though sometimes pointless
 ItReturns "$zfSnap -n -r fake_zpool0 fake_zpool1"       0 # more than one zpool
 ItReturns "$zfSnap -n fake_zpool0 fake_zpoool1 -r fake_zpool2"  0 # pool option declared between zpools
 

--- a/zfSnap.8
+++ b/zfSnap.8
@@ -18,8 +18,6 @@
 .Op Fl S
 .Op Fl v
 .Op Fl z
-.Oc
-.Oo
 .Op Fl a Ar ttl
 .Op Fl D Ar pool/fs
 .Op Fl p Ar prefix
@@ -45,13 +43,24 @@ Time\[hy]To\[hy]Live
 .Pq TTL
 is the length of time to keep a snapshot before it's ready for deletion.
 .
-.Ss Generic Options
-These options apply to
-.Nm
-as a whole. Declaring them more than once will have no effect.
+.Ss Options
+Options and arguments are operated on as they are read
+.Pq sequentially .
+Keep this in mind while building calls to
+.Nm .
 .Bl -tag -width Ds
+.It Fl a Ar TTL
+Set how long the snapshot should be kept. If not set, the default
+.Ar TTL
+is one month. See
+.Sx TTL SYNTAX
+for more information.
 .It Fl d
 Delete old snapshots.
+.It Fl D Ar pool/fs
+Delete all zfSnap snapshots of
+.Ar pool/fs
+regardless of their TTL expiration.
 .It Fl e
 Return the number of failed actions as the exit code.
 .It Fl F Ar age
@@ -63,30 +72,6 @@ regardless of their TTL expiration.
 Print a summary of the command-line options and then exit.
 .It Fl n
 Dry\[hy]run. Perform a trial run with no actions actually performed.
-.It Fl s
-Skip pools that are resilvering.
-.It Fl S
-Skip pools that are scrubbing.
-.It Fl v
-Verbose output.
-.It Fl z
-Round snapshot creation time down to 00 seconds.
-.El
-.
-.Ss Options
-These options apply to the snapshots which follow them. These options can be used
-multiple times and can override each other.
-.Bl -tag -width Ds
-.It Fl a Ar TTL
-Set how long the snapshot should be kept. If not set, the default
-.Ar TTL
-is one month. See
-.Sx TTL SYNTAX
-for more information.
-.It Fl D Ar pool/fs
-Delete all zfSnap snapshots of
-.Ar pool/fs
-regardless of their TTL expiration.
 .It Fl p Ar prefix
 Use
 .Ar prefix
@@ -97,6 +82,14 @@ Don't use a prefix for snapshots after this switch.
 Create recursive snapshots of all ZFS file systems that follow this switch.
 .It Fl R
 Create non\[hy]recursive snapshots for all ZFS file systems that follow this switch.
+.It Fl s
+Skip pools that are resilvering.
+.It Fl S
+Skip pools that are scrubbing.
+.It Fl v
+Verbose output.
+.It Fl z
+Round snapshot creation time down to 00 seconds.
 .El
 .
 .Sh TTL SYNTAX


### PR DESCRIPTION
This patch set uses the more standard getopts functionality to parse scripting options and makes a few fixes to behavior. The main advantages (over current functionality) of this patch set are:

1) option argument requirements are enforced
2) unknown options exit, rather than being ignored and continued (which was dangerous IMO)
3) more concise
4) more standard
5) comes with (a few) tests

I was concerned about the portability of getopts, but apparently that was unfounded. It is POSIX compliant, and support extends all the way back to SVR4.

Please note that getopts only supports short options. This means that I did not port zpool28fix. However, issue #17 is about removing that option and just detecting the situation. If this patch set is merged, that issue should be resolved before the next release is tagged. I have looked at Issue #17, but I am unsure if the bad behavior is specific to all v28 pools, just some v28 pools on FreeBSD, all v28 pools on all OSs, or some other combination thereof. I also do not have access to a FreeBSD box to test.

---Alex
