### PR TITLE
Convert TTL2Seconds to sh

### DIFF
--- a/share/zfSnap/commands/destroy.sh
+++ b/share/zfSnap/commands/destroy.sh
@@ -78,7 +78,7 @@ while [ "$1" ]; do
             rm_snapshots=$zfs_snapshots
         else
             current_time=`date +%s`
-            # TODO, both create_time and stay_time could be cached
+            # TODO, create_time could be cached
             for i in $zfs_snapshots; do
                 snapshot_name=${i#*@}
                 create_time=$(Date2Timestamp `echo "$snapshot_name" | $ESED -e "s/--${ttl_pattern}$//; s/^(${prefixes})?//"`)

--- a/share/zfSnap/core.sh
+++ b/share/zfSnap/core.sh
@@ -183,8 +183,22 @@ SkipPool() {
 
 # Converts TTL to seconds
 TTL2Seconds() {
-    # convert human readable time to seconds
-    echo "$1" | sed -e 's/y/*31536000+/g; s/m/*2592000+/g; s/w/*604800+/g; s/d/*86400+/g; s/h/*3600+/g; s/M/*60+/g; s/s//g; s/\+$//' | bc -l
+    ttl="$1"
+    seconds=0
+    while [ "$ttl" ]; do
+        case "$ttl" in
+            *y*) seconds=$(($seconds + (${ttl%%y*} * 31536000))); ttl=${ttl##*y} ;;
+            *m*) seconds=$(($seconds + (${ttl%%m*} * 2592000))); ttl=${ttl##*m} ;;
+            *w*) seconds=$(($seconds + (${ttl%%w*} * 604800))); ttl=${ttl##*w} ;;
+            *d*) seconds=$(($seconds + (${ttl%%d*} * 86400))); ttl=${ttl##*d} ;;
+            *h*) seconds=$(($seconds + (${ttl%%h*} * 3600))); ttl=${ttl##*h} ;;
+            *M*) seconds=$(($seconds + (${ttl%%M*} * 60))); ttl=${ttl##*M} ;;
+             *s) seconds=$(($seconds + ${ttl%%s*})); ttl=${ttl##*s} ;;
+              *) Fatal "TTL2Seconds could not convert '$1'!" ;;
+        esac
+    done
+
+    printf "$seconds"
 }
 
 # Check validity of TTL

--- a/tests/unit/ttl_2_seconds.sh
+++ b/tests/unit/ttl_2_seconds.sh
@@ -3,7 +3,7 @@
 . ../spec_helper.sh
 . ../../share/zfSnap/core.sh
 
-ItEchos "TTL2Seconds ''"              ""
+ItEchos "TTL2Seconds ''"              "0"
 ItEchos "TTL2Seconds '1s'"            "1"
 ItEchos "TTL2Seconds '59s'"           "59"
 ItEchos "TTL2Seconds '1M'"            "60"


### PR DESCRIPTION
Removes two external calls (grep and bc). This code is faster, and the performance improvements mean that there is no need for $stay_time to be cached.

Also, modified one test case. IMO, a TTL of ' ' (though invalid) should be 0, as it is indeed "nothing."

I mulled over whether TTL2Seconds should throw some error if the TTL is invalid, however, the ValidTTL function is there for a reason, and we should take care to protect TTL2Seconds with it.
