### PR TITLE
Replace > /dev/stderr with >&2

### DIFF
--- a/periodic/xPERIODICx_zfsnap.sh
+++ b/periodic/xPERIODICx_zfsnap.sh
@@ -44,7 +44,7 @@ case "${xPERIODICx_zfsnap_enable-"NO"}" in
                 default_ttl='6m'
                 ;;
             *)
-                printf '%s\n' "ERR: Unexpected error" > /dev/stderr
+                printf '%s\n' "ERR: Unexpected error" >&2
                 exit 1
                 ;;
         esac

--- a/share/zfsnap/commands/destroy.sh
+++ b/share/zfsnap/commands/destroy.sh
@@ -70,7 +70,7 @@ while [ "$1" ]; do
 
     # operate on pool/fs supplied
     if [ "$1" ]; then
-        ZFS_SNAPSHOTS=`$ZFS_CMD list -H -o name -t snapshot -r $1` > /dev/stderr || Fatal "'$1' does not exist!"
+        ZFS_SNAPSHOTS=`$ZFS_CMD list -H -o name -t snapshot -r $1` >&2 || Fatal "'$1' does not exist!"
         ! SkipPool "$1" && shift && continue
 
         for SNAPSHOT in $ZFS_SNAPSHOTS; do

--- a/share/zfsnap/commands/snapshot.sh
+++ b/share/zfsnap/commands/snapshot.sh
@@ -72,7 +72,7 @@ while [ "$1" ]; do
 
         ZFS_SNAPSHOT="$ZFS_CMD snapshot $ZOPT ${1}@${PREFIX}${CURRENT_DATE}--${TTL}"
         if IsFalse "$DRY_RUN"; then
-            if $ZFS_SNAPSHOT > /dev/stderr; then
+            if $ZFS_SNAPSHOT >&2; then
                 IsTrue $VERBOSE && printf '%s ... DONE\n' "$ZFS_SNAPSHOT"
             else
                 IsTrue $VERBOSE && printf '%s ... FAIL\n' "$ZFS_SNAPSHOT"

--- a/share/zfsnap/core.sh
+++ b/share/zfsnap/core.sh
@@ -29,20 +29,20 @@ RETVAL=''                           # used by functions so we can avoid spawning
 
 ## HELPER FUNCTIONS
 Err() {
-    printf '%s\n' "ERROR: $*" > /dev/stderr
+    printf '%s\n' "ERROR: $*" >&2
 }
 Exit() {
     IsTrue "$TEST_MODE" || exit $1
 }
 Fatal() {
-    printf '%s\n' "FATAL: $*" > /dev/stderr
+    printf '%s\n' "FATAL: $*" >&2
     exit 1
 }
 Note() {
-    printf '%s\n' "NOTE: $*" > /dev/stderr
+    printf '%s\n' "NOTE: $*" >&2
 }
 Warn() {
-    printf '%s\n' "WARNING: $*" > /dev/stderr
+    printf '%s\n' "WARNING: $*" >&2
 }
 
 # Returns 0 if argument is "false"
@@ -217,7 +217,7 @@ RmZfsSnapshot() {
     # hardening: make really, really sure we are deleting a snapshot
     if IsSnapshot "$1"; then
         if IsFalse "$DRY_RUN"; then
-            if $zfs_destroy > /dev/stderr; then
+            if $zfs_destroy >&2; then
                 IsTrue $VERBOSE && printf '%s ... DONE\n' "$zfs_destroy"
             else
                 IsTrue $VERBOSE && printf '%s ... FAIL\n' "$zfs_destroy"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -16,6 +16,6 @@ done
 if [ $exit_with_error -eq 0 ]; then
     printf "\n\033[1;32m%s\033[0m\n" "All tests passed."
 else
-    printf "\n\033[1;31m%s\033[0m\n" "Some tests failed." > /dev/stderr
+    printf "\n\033[1;31m%s\033[0m\n" "Some tests failed." >&2
     exit 1
 fi


### PR DESCRIPTION
This will avoid errors like:
/dev/stderr: No such device or address

e.g. when running zfsnap in a systemd unit