### PR TITLE
Improve output of ItsRetavlIs

### DIFF
--- a/tests/spec_helper.sh
+++ b/tests/spec_helper.sh
@@ -34,7 +34,7 @@ ItsRetvalIs() {
   local actual_return="$?"
   local actual_retval="$RETVAL"
 
-  printf '`%s` retvals "%s" and %s ... ' "$cmd" "$expected_retval" "$expected_return"
+  printf '`%s` sets retval to "%s" and returns %s ... ' "$cmd" "$expected_retval" "$expected_return"
   if [ "$expected_retval" = "$actual_retval" ] && [ "$expected_return" -eq "$actual_return" ]; then
     printf '\033[1;32mpassed\033[0m\n'
   else


### PR DESCRIPTION
Prior fix it would output something like
```
`TrimToPrefix '2011-04-05_02.06.00--1y'` retvals "" and 0 ... passed
```

after

```
`TrimToPrefix '2011-04-05_02.06.00--1y'` sets retval to "" and returns 0 ... passed
```

I think the later is much more readable.