### PR TITLE
Reset OPTIND in loops that use getopts.

### DIFF
--- a/share/zfsnap/commands/destroy.sh
+++ b/share/zfsnap/commands/destroy.sh
@@ -46,6 +46,7 @@ EOF
 
 # main loop; get options, process snapshot expiration/deletion
 while [ -n "$1" ]; do
+    OPTIND=1
     while getopts :DF:hnp:PrRsSvz OPT; do
         case "$OPT" in
             D) DELETE_ALL_SNAPSHOTS='true';;

--- a/share/zfsnap/commands/recurseback.sh
+++ b/share/zfsnap/commands/recurseback.sh
@@ -41,6 +41,7 @@ EOF
 
 # main loop; get options, process snapshot creation
 while [ -n "$1" ]; do
+	OPTIND=1
     while getopts :d:fhnrRv OPT; do
         case "$OPT" in
             d) DEPTH="-d $OPTARG";;

--- a/share/zfsnap/commands/snapshot.sh
+++ b/share/zfsnap/commands/snapshot.sh
@@ -41,6 +41,7 @@ EOF
 
 # main loop; get options, process snapshot creation
 while [ "$1" ]; do
+    OPTIND=1
     while getopts :a:hnp:PrRsSvz OPT; do
         case "$OPT" in
             a) ValidTTL "$OPTARG" || Fatal "Invalid TTL: $OPTARG"


### PR DESCRIPTION
In bash, and probably some other shells, failing to reset OPTIND to 1 after shifting the argument list and before calling getopts subsequent times will cause it not to parse any more arguments. The end result is that the scripts would miss any further arguments after the first filesystem name.

For instance, if I issued this command:

  `zfsnap snapshot -r -p weekly- -a 2m tank/backups -a 1m pony media`

then snapshots would only be added to tank/backups. That's because the `shift $(($OPTIND - 1))` statement would shift by 5, the script would go on to process the next argument, `tank/backups` and then shift by 1 more. That leaves the final four arguments, but OPTIND would still be at 6 when the next invocation of getopts happens at the top of the loop. So getopts would do nothing, and we'd then shift by 5 again, leaving apparently nothing left to do. I suppose things would get even worse if I had lots of arguments after the first five...

Perhaps some shells reset OPTIND for each invocation of getopts. Bash, at least, does not.