### PR TITLE
Add -f option for limiting snapshot frequency

### DIFF
--- a/share/zfsnap/commands/snapshot.sh
+++ b/share/zfsnap/commands/snapshot.sh
@@ -4,6 +4,8 @@
 # See the AUTHORS and LICENSE files for more information.
 
 PREFIX=''                           # Default prefix
+PREFIXES=''                         # Needed for searching recent snapshots
+SNAPSHOT_FREQ=''                    # Max allowed snapshot frequency
 
 # FUNCTIONS
 Help() {
@@ -16,6 +18,9 @@ ${0##*/} snapshot [ options ] zpool/filesystem ...
 OPTIONS:
   -a ttl       = How long the snapshot(s) should be kept (default: 1 month)
   -h           = Print this help and exit
+  -f age       = Maximum frequency with which snapshots should be created. (Will
+                 not create a new snapshot if an existing one is younger than
+                 this limit.)
   -n           = Dry-run. Perform a trial run with no actions actually performed
   -p prefix    = Prefix to use when naming snapshots for all ZFS file
                  systems that follow this option
@@ -41,12 +46,15 @@ EOF
 
 # main loop; get options, process snapshot creation
 while [ "$1" ]; do
-    while getopts :a:hnp:PrRsSvz OPT; do
+    while getopts :a:hf:np:PrRsSvz OPT; do
         case "$OPT" in
             a) ValidTTL "$OPTARG" || Fatal "Invalid TTL: $OPTARG"
                TTL=$OPTARG
                ;;
             h) Help;;
+            f) ValidTTL "$OPTARG" || Fatal "Invalid Duration: $OPTARG"
+               SNAPSHOT_FREQ=$OPTARG
+               ;;
             n) DRY_RUN='true';;
             p) PREFIX=$OPTARG;;
             P) PREFIX='';;
@@ -62,6 +70,9 @@ while [ "$1" ]; do
         esac
     done
 
+    # This must be set for "ValidPrefix" to work properly
+    PREFIXES=$PREFIX
+
     # discard all arguments processed thus far
     shift $(($OPTIND - 1))
 
@@ -71,6 +82,33 @@ while [ "$1" ]; do
         ! SkipPool "$1" && shift && continue
 
         CURRENT_DATE=${CURRENT_DATE:-`date "+$TIME_FORMAT"`}
+
+        if [ -n "$SNAPSHOT_FREQ" ]; then
+            # Check if there is already a recent snapshot within
+            # $SNAPSHOT_FREQ of current date
+            ZFS_SNAPSHOTS=`$ZFS_CMD list -H -o name -t snapshot -r $1` >&2 || Fatal "'$1' does not exist!"
+            # Get the earliest date when the next snapshot should be created
+            SNAPSHOT_ALLOWED_DATE=''
+            for SNAPSHOT in $ZFS_SNAPSHOTS; do
+                TrimToFileSystem "$SNAPSHOT" && [ "$RETVAL" = "$1" ] || continue
+
+                # gets and validates snapshot name
+                TrimToSnapshotName "$SNAPSHOT" && SNAPSHOT_NAME=$RETVAL || continue
+
+                TrimToDate "$SNAPSHOT_NAME" && CREATE_DATE=$RETVAL || continue
+                DatePlusTTL "$CREATE_DATE" "$SNAPSHOT_FREQ" && FREQ_EXPIRE_DATE=$RETVAL || continue
+                if [ -z "$SNAPSHOT_ALLOWED_DATE" ] ||
+                       GreaterDate $FREQ_EXPIRE_DATE $SNAPSHOT_ALLOWED_DATE; then
+                    SNAPSHOT_ALLOWED_DATE=$FREQ_EXPIRE_DATE;
+                fi
+            done
+            # If previous snapshot is too young, don't create a new
+            # one
+            if [ -n "$SNAPSHOT_ALLOWED_DATE" ] &&
+                   GreaterDate $SNAPSHOT_ALLOWED_DATE $CURRENT_DATE; then
+                shift && continue;
+            fi
+        fi
 
         ZFS_SNAPSHOT="$ZFS_CMD snapshot $ZOPT ${1}@${PREFIX}${CURRENT_DATE}--${TTL}"
         if IsFalse "$DRY_RUN"; then


### PR DESCRIPTION
Here is a potentially simpler alternative to #72 to solve #71. It just adds a `-f` option to `zfsnap snapshot` that prevents snapshot creation unless all existing snapshots with the specified prefix are older than the specified age. The idea is to run this in a frequently-executed cronjob. For example, I've set up the following daily cron job on my server:

```bash 
#!/bin/bash

# Sync root FS (which is not ZFS) to ZFS for snapshotting
ionice -c3 rsync -aAHX --quiet --one-file-system / /rpool/ubuntu/root-backup/

# Daily snapshot
/usr/local/sbin/zfsnap snapshot -p zfsnap-daily- -f 1d -a 2w -z -r rpool
# Weekly
/usr/local/sbin/zfsnap snapshot -p zfsnap-weekly- -f 1w -a 2m -z -r rpool
# Monthly
/usr/local/sbin/zfsnap snapshot -p zfsnap-monthly- -f 1m -a 2y -z -r rpool
# Yearly
/usr/local/sbin/zfsnap snapshot -p zfsnap-yearly- -f 1y -a 10y -z -r rpool

# Clean up expired snapshots
for prefix in zfsnap-{daily,weekly,monthly,yearly}-; do
        /usr/local/sbin/zfsnap destroy -p "$prefix" -r rpool
done
```

Another possible use case would be a server that is not expected to run continuously at all times. In this case, you could put something like the above in an hourly cron job, to ensure that snapshots will not be skipped simply because the server is never running at the appropriate time. 