### PR TITLE
Sort snapshots by name when listing snapshot names.

### DIFF
--- a/completion/zfsnap-completion.bash
+++ b/completion/zfsnap-completion.bash
@@ -42,7 +42,7 @@ __zfsnap_list_datasets() {
 # prints zfs snapshots
 __zfsnap_list_snapshots() {
     local dataset=${1%@*}
-    $__ZFSNAP_ZFS list -H -t snapshot -o name -d 1 -r $dataset
+    $__ZFSNAP_ZFS list -H -t snapshot -o name -s name -d 1 -r $dataset
 }
 
 # prints valid flags of a given command

--- a/share/zfsnap/commands/destroy.sh
+++ b/share/zfsnap/commands/destroy.sh
@@ -75,7 +75,7 @@ while [ -n "$1" ]; do
 
     # operate on pool/fs supplied
     if [ -n "$1" ]; then
-        ZFS_SNAPSHOTS=`$ZFS_CMD list -H -o name -t snapshot -r $1` >&2 || Fatal "'$1' does not exist!"
+        ZFS_SNAPSHOTS=`$ZFS_CMD list -H -o name -s name -t snapshot -r $1` >&2 || Fatal "'$1' does not exist!"
         ! SkipPool "$1" && shift && continue
 
         for SNAPSHOT in $ZFS_SNAPSHOTS; do

--- a/share/zfsnap/commands/recurseback.sh
+++ b/share/zfsnap/commands/recurseback.sh
@@ -66,7 +66,7 @@ while [ -n "$1" ]; do
     # rollback
     if [ -n "$1" ]; then
         IsSnapshot "$1" || Fatal "You must provide a snapshot to rollback to."
-        $ZFS_CMD list -H -t snapshot -o name "$1" > /dev/null || Fatal "'$1' does not exist!"
+        $ZFS_CMD list -H -t snapshot -o name -s name "$1" > /dev/null || Fatal "'$1' does not exist!"
         TrimToFileSystem "$1" && FS_NAME=$RETVAL
         SNAPSHOT_NAME=${1##${FS_NAME}@}
 


### PR DESCRIPTION
This provides a dramatical speedup on FreeBSD and Linux:
http://svnweb.freebsd.org/base?view=revision&revision=230438
https://github.com/zfsonlinux/zfs/commit/0cee2406

I did not find the relevancy of sorting by date in zfsnap so this should be ok. On other platforms this has no effect yet. (I am in process of submitting that code to OpenZFS codebase)