### PR TITLE
Store TTL as ZFS property . Resolve zfsnap/zfsnap#89

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,6 @@ The primary authors of zfsnap are (and/or have been)
 
  * Aldis Berjoza <graudeejs@yandex.com>
  * Alex Waite <alex@waite.eu>
+ 
+ Modified by
+ * Alberto Maria Fiaschi <alberto.fiaschi@gmail.com>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+ #!/bin/bash
+ install -o root -g root -m u+rx  sbin/zfsnap.sh  /usr/sbin/
+ install -o root -g users -d /usr/share/zfsnap
+ install -o root -g users -d /usr/share/zfsnap/commands
+ install -o root -g root share/zfsnap/core.sh /usr/share/zfsnap/core.sh
+ install -o root -g root -m ug+rx share/zfsnap/core.sh /usr/share/zfsnap/core.sh
+ install -o root -g root -m ug+rx share/zfsnap/commands/*.sh  /usr/share/zfsnap/commands/
+ install -o root -g users  -m a+r man/man8/zfsnap.8  /usr/share/man/man8/
+ install -o root -g users  -m ug+r+x completion/zfsnap-completion.bash  /etc/bash_completion.d/zfsnap
+ install -o root -g users  -d /usr/share/doc/zfsnap
+ install -o root -g users  -m ug+r+x+w AUTHORS INSTALL LICENSE NEWS PORTABILITY README.md    /usr/share/doc/zfsnap

--- a/man/man8/zfsnap.8
+++ b/man/man8/zfsnap.8
@@ -21,10 +21,18 @@
 .Nm
 creates and deletes rolling ZFS snapshots \[em] usually with cron.
 .Nm Ap s
-main advantages are its portability and that all information needed for
-snapshot management is kept in the snapshot name itself.
+main advantages are its portability.Original  version store all information needed for
+snapshot management in the snapshot name itself. But this is not very convenient for
+many uses. (Ex.  samba vfs_shadow_copy2)
 .Pp
-zfsnap snapshots are in the format of pool/fs@[prefix]Timestamp\-\-TimeToLive
+ zfsnap snapshots are in the format of pool/fs@[prefix]Timestamp
+ TimeToLive is  stored in zfs property (default zfsnap:ttl).
+ Usual commands zfs get/set to read/modify.
+.Pq e.g. zpool/var@monthly\-2010\-08\-03_02.06.00
+.Pq zfs get zfsnap:ttl zpool/var@monthly\-2010\-08\-03_02.06.00
+.Pq zfs list -t snapshot -o name,zfsnap:ttl
+.Pp
+old zfsnap snapshots are in the format of pool/fs@[prefix]Timestamp\-\-TimeToLive
 .Pq e.g. zpool/var@monthly\-2010\-08\-03_02.06.00\-\-1y .
 .Pp
 The prefix is optional and is quite useful for filtering; Timestamp is the date
@@ -76,6 +84,8 @@ By default,
 .Nm Cm destroy
 will only delete snapshots whose TTLs have expired. However, options
 are provided to override that behavior with more aggressive approaches.
+New version is still compatible with snapshots with ttl stored in snapshot name. 
+If the ttl is both in  name and  zfs property, only the zfs property is considered.
 .Pp
 Only snapshots created by
 .Nm
@@ -164,6 +174,8 @@ for more information.
 Print a summary of
 .Cm snapshot Ap s
 command\[hy]line options and then exit.
+.It Fl L
+Legacy write ttl in  name instead to use new default  zfs property zfsnap:ttl.
 .It Fl n
 Dry\[hy]run. Perform a trial run with no actions actually performed.
 .It Fl p Ar prefix

--- a/sbin/zfsnap.sh
+++ b/sbin/zfsnap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is licensed under the BSD-3-Clause license.
 # See the AUTHORS and LICENSE files for more information.

--- a/share/zfsnap/commands/destroy.sh
+++ b/share/zfsnap/commands/destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is licensed under the BSD-3-Clause license.
 # See the AUTHORS and LICENSE files for more information.
@@ -93,7 +93,13 @@ while [ -n "$1" ]; do
                 if IsTrue "$FORCE_DELETE_BY_AGE"; then
                     DatePlusTTL "$CREATE_DATE" "$FORCE_AGE_TTL" && EXPIRATION_DATE=$RETVAL || continue
                 else
-                    TrimToTTL "$SNAPSHOT_NAME" && TTL=$RETVAL || continue
+					if GetZfsPropTTL "$SNAPSHOT"; then
+						TTL=$RETVAL 
+					elif  TrimToTTL "$SNAPSHOT_NAME"; then
+					        TTL=$RETVAL
+					else
+                                            continue
+					fi 
                     [ "$TTL" = 'forever' ] && continue
                     DatePlusTTL "$CREATE_DATE" "$TTL" && EXPIRATION_DATE=$RETVAL || continue
                 fi

--- a/share/zfsnap/commands/recurseback.sh
+++ b/share/zfsnap/commands/recurseback.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is licensed under the BSD-3-Clause license.
 # See the AUTHORS and LICENSE files for more information.

--- a/tests/integration/getopts.sh
+++ b/tests/integration/getopts.sh
@@ -14,6 +14,7 @@ ItReturns "$zfsnap snapshot -g 2> /dev/null"                                  1 
 
 # These are valid scenarios and should be accepted
 ItReturns "$zfsnap snapshot -n -v -v 2> /dev/null"                            0 # option twice is ok, though sometimes pointless
+ItReturns "$zfsnap snapshot -n -v -t 2> /dev/null"                            0 # option t set ttl in zfs property
 #ItReturns "$zfsnap snapshot -n -r fake_zpool0 fake_zpool1 2> /dev/null"       0 # more than one zpool
 #ItReturns "$zfsnap snapshot -n fake_zpool0 fake_zpoool1 -r fake_zpool2 2> /dev/null"  0 # pool option declared between zpools
 


### PR DESCRIPTION
By default store TimeToLive in zfs property . zfsnap destroy is
still compatible with TTL stored in the name.
Legacy option zfsnap  snapshot  -L to store TTL in name.
This resolve zfsnap/zfsnap#89.
( Samba vfs_shadow_copy2 does not support suffixes in snapshots)