### PR TITLE
Add basic ssh capabilities to work on remote pools

### DIFF
--- a/man/man8/zfsnap.8
+++ b/man/man8/zfsnap.8
@@ -12,6 +12,8 @@
 .Nm
 .Op Fl h
 .Op Fl V
+.Op Fl s
+.Ar <args>
 |
 .Ar <command>
 .Op options
@@ -44,6 +46,8 @@ Print a summary of
 command\[hy]line options and then exit.
 .It Fl V
 Print the version number and exit.
+.It Fl s
+Use ssh to run all zfs/zpool commands on a remote host. Use parentheses to pass options to ssh, e.g. "-p 2223 user@host". See ssh(1) manual page for all options.
 .El
 .Pp
 .Nm

--- a/sbin/zfsnap.sh
+++ b/sbin/zfsnap.sh
@@ -38,8 +38,9 @@ COMMANDS:
 `for C in $ZFSNAP_LIB_DIR/commands/*.sh; do [ -f "$C" ] && C_NAME="${C##*/}" && printf '  %s\n' "${C_NAME%.*}"; done`
 
 OPTIONS:
-  -h, --help        = Print this help and exit
-  -V, --version     = Print the version number and exit
+  -h, --help                = Print this help and exit
+  -V, --version             = Print the version number and exit
+  -s <args>, --ssh <args>   = Use ssh to run zfs/zpool commands on remote host
 
 MORE HELP:
   All commands accept the -h option; use it for command-specific help.
@@ -60,6 +61,15 @@ case "$1" in
     '-V'|'--version')
         printf '%s v%s\n' "${0##*/}" "${VERSION}"; Exit 0;;
     *)
+        case "$1" in
+            '-s'|'--ssh')
+                shift
+                REMOTE_HOST=$1
+                ZFS_CMD="ssh $REMOTE_HOST $ZFS_CMD"
+                ZPOOL_CMD="ssh $REMOTE_HOST $ZFS_CMD"
+                shift;;
+        esac
+
         CMD="$1"
         if [ -f "${ZFSNAP_LIB_DIR}/commands/${CMD}.sh" ]; then
             shift


### PR DESCRIPTION
SSH usage is triggered with the added -s <args> option for zfsnap:
zfsnap -s user@host snapshot -a 1h pool/dataset

Implementation is _very_ simplistic: When the -s option is used, $ZFS_CMD and
$ZPOOL_CMD are simply prefixed with "ssh <args>".
Options to SSH can be passed by using parentheses around the arguments for -s:
zfsnap -s "-p 1234 user@host" snapshot -a 1h pool/dataset