### PR TITLE
Adjust ValidPrefix function

### DIFF
--- a/share/zfsnap/core.sh
+++ b/share/zfsnap/core.sh
@@ -438,7 +438,7 @@ ValidDate() {
 ValidPrefix() {
     local snapshot_prefix="$1"
 
-    [ -z "$PREFIXES" ] && [ -z "$snapshot_prefix" ] && return 0
+    [ -z "$PREFIXES" ] && return 0
 
     local i
     for i in $PREFIXES; do


### PR DESCRIPTION
Adjusted conditionals such that if no valid prefix list is specified, all prefixes and no prefix in snapshot name return true.  This enables the destroy -P option to work as expected.  Without this change, -P clears the valid prefix list ($PREFIXES) and causes true to be returned only for snapshots with no prefix.  With this change, now commands like zfsnap destroy -P -r <pool> will clean out all expired snapshots regardless of prefix.