### PR TITLE
Fix #116: assume that filtering by prefix keeps snaps with no filter

### DIFF
--- a/share/zfsnap/core.sh
+++ b/share/zfsnap/core.sh
@@ -438,7 +438,12 @@ ValidDate() {
 ValidPrefix() {
     local snapshot_prefix="$1"
 
-    [ -z "$PREFIXES" ] && [ -z "$snapshot_prefix" ] && return 0
+    # if there are no filter prefixes specified, then always succeed
+    [ -z "$PREFIXES" ] && return 0
+
+    # if there are filter prefixes specified, but this snap
+    # doesn't have a prefix, then fail.
+    [ -n "$PREFIXES" ] && [ -z "$snapshot_prefix" ] && return 1
 
     local i
     for i in $PREFIXES; do


### PR DESCRIPTION
The original test in ValidPrefix only succeeded under two conditions:

1) No filter prefixes were specified on the command line, and the current snap name didn't have a prefix, or,
2) Filter prefixes were specified on the command line, and the current snap had a matching prefix.

The documentation strongly implies that if I don't specify any filter prefixes (or if I specify '-P'), that all expired snapshots will be destroyed regardless of of prefix. So, this code now has three conditions:

1) If no filter prefixes were specified, then we don't need to check anything => succeed;
2) (special case) If filter prefixes were specified and the current snapshot name doesn't have a prefix => fail;
3) compare current snapshot's prefix to the list of prefixes specified and return appropriately.