### PR TITLE
CI: Update FreeBSD images to 14.2 and 13.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ env:
 Tests_task:
   matrix:
     freebsd_instance:
-      image_family: freebsd-13-2
+      image_family: freebsd-14-2
     freebsd_instance:
-      image_family: freebsd-12-4
+      image_family: freebsd-13-4
   prepare_script:
   - cd tests && sh prepare.sh
   test_script:


### PR DESCRIPTION
FreeBSD 12.4 and 13.2 are not supported by Cirrus CI anymore.
The tests should be all-green after #123 is merged.